### PR TITLE
OrbitControlsでmousemoveが取れない問題を対処

### DIFF
--- a/app/lib/three/OrbitControls.js
+++ b/app/lib/three/OrbitControls.js
@@ -218,8 +218,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 		scope.domElement.removeEventListener( 'touchend', onTouchEnd, false );
 		scope.domElement.removeEventListener( 'touchmove', onTouchMove, false );
 
-		document.removeEventListener( 'mousemove', onMouseMove, false );
-		document.removeEventListener( 'mouseup', onMouseUp, false );
+		scope.domElement.removeEventListener( 'mousemove', onMouseMove, false );
+		scope.domElement.removeEventListener( 'mouseup', onMouseUp, false );
 
 		window.removeEventListener( 'keydown', onKeyDown, false );
 
@@ -682,8 +682,8 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 		if ( state !== STATE.NONE ) {
 
-			document.addEventListener( 'mousemove', onMouseMove, false );
-			document.addEventListener( 'mouseup', onMouseUp, false );
+			scope.domElement.addEventListener( 'mousemove', onMouseMove, false );
+			scope.domElement.addEventListener( 'mouseup', onMouseUp, false );
 
 			scope.dispatchEvent( startEvent );
 


### PR DESCRIPTION
webgl_editron で `OrbitControls` を使用したときにマウスの移動が取得できない問題に対する修正です。